### PR TITLE
Clarify what notebook version means

### DIFF
--- a/lisp/ein-contents-api.el
+++ b/lisp/ein-contents-api.el
@@ -68,7 +68,7 @@ global setting.  For global setting and more information, see
   (apply #'ein:content-url* (ein:$content-url-or-port content) (ein:$content-path content) params))
 
 (defun ein:content-url* (url-or-port path &rest params)
-  (let* ((which (if (<= (ein:need-notebook-version url-or-port) 2)
+  (let* ((which (if (< (ein:notebook-version-numeric url-or-port) 3)
                     "notebooks" "contents"))
          (api-path (concat "api/" which)))
     (url-encode-url (apply #'ein:url
@@ -116,7 +116,7 @@ global setting.  For global setting and more information, see
                                                          &key data symbol-status response
                                                          &allow-other-keys)
   (let (content)
-    (if (<= (ein:need-notebook-version url-or-port) 2)
+    (if (< (ein:notebook-version-numeric url-or-port) 3)
         (setq content (ein:new-content-legacy url-or-port path data))
       (setq content (ein:new-content url-or-port path data)))
     (ein:aif response
@@ -173,7 +173,7 @@ global setting.  For global setting and more information, see
       (ein:new-content url-or-port path data)
     (let ((content (make-ein:$content
                     :url-or-port url-or-port
-                    :notebook-version (ein:need-notebook-version url-or-port)
+                    :notebook-version (ein:notebook-version-numeric url-or-port)
                     :path path)))
       (setf (ein:$content-name content) (substring path (or (cl-position ?/ path) 0))
             (ein:$content-path content) path
@@ -190,7 +190,7 @@ global setting.  For global setting and more information, see
   ;; data is like (:size 72 :content nil :writable t :path Untitled7.ipynb :name Untitled7.ipynb :type notebook)
   (let ((content (make-ein:$content
                   :url-or-port url-or-port
-                  :notebook-version (ein:need-notebook-version url-or-port)
+                  :notebook-version (ein:notebook-version-numeric url-or-port)
                   :path path)))
     (setf (ein:$content-name content) (plist-get data :name)
           (ein:$content-path content) (plist-get data :path)
@@ -377,7 +377,7 @@ global setting.  For global setting and more information, see
 
 (defun* ein:content-query-sessions--success (url-or-port callback &key data &allow-other-keys)
   (cl-flet ((read-name (nb-json)
-                       (if (= (ein:need-notebook-version url-or-port) 2)
+                       (if (< (ein:notebook-version-numeric url-or-port) 3)
                            (if (string= (plist-get nb-json :path) "")
                                (plist-get nb-json :name)
                              (format "%s/%s" (plist-get nb-json :path) (plist-get nb-json :name)))

--- a/lisp/ein-core.el
+++ b/lisp/ein-core.el
@@ -206,18 +206,14 @@ the source is in git repository) or elpa version."
                                                      &aux (resp-string (format "STATUS: %s DATA: %s" (request-response-status-code response) data)))
   (ein:log 'debug "ein:query-kernelspecs--complete %s" resp-string))
 
-(defsubst ein:get-ipython-major-version (vstr)
-  (if vstr
-      (string-to-number (car (split-string vstr "\\.")))
-    (if (>= ein:log-level (ein:log-level-name-to-int 'debug))
-        (throw 'error "Null value passed to ein:get-ipython-major-version.")
-      (ein:log 'warn "Null value passed to ein:get-ipython-major-version."))))
+(defsubst ein:notebook-version-numeric (url-or-port)
+  (truncate (string-to-number (ein:need-notebook-version url-or-port))))
 
 (defun ein:need-notebook-version (url-or-port)
   "Callers assume ein:query-notebook-version succeeded.  If not, we hardcode a guess."
   (ein:aif (gethash url-or-port *ein:notebook-version*) it
     (ein:log 'warn "No recorded notebook version for %s" url-or-port)
-    5))
+    "5.7.0"))
 
 (defun ein:query-notebook-version (url-or-port callback)
   "Send for notebook version of URL-OR-PORT with CALLBACK arity 0 (just a semaphore)"
@@ -234,11 +230,10 @@ the source is in git repository) or elpa version."
                                              &aux (resp-string (format "STATUS: %s DATA: %s" (request-response-status-code response) data)))
   (ein:log 'debug "ein:query-notebook-version--complete %s" resp-string)
   (ein:aif (plist-get data :version)
-      (setf (gethash url-or-port *ein:notebook-version*)
-            (ein:get-ipython-major-version it))
+      (setf (gethash url-or-port *ein:notebook-version*) it)
     (case (request-response-status-code response)
       (404 (ein:log 'warn "notebook version api not implemented")
-           (setf (gethash url-or-port *ein:notebook-version*) 2))
+           (setf (gethash url-or-port *ein:notebook-version*) "2.0.0"))
       (t (ein:log 'warn "notebook version currently unknowable"))))
   (when callback (funcall callback)))
 

--- a/lisp/ein-notebooklist.el
+++ b/lisp/ein-notebooklist.el
@@ -414,7 +414,7 @@ This function is called via `ein:notebook-after-rename-hook'."
                                                 &allow-other-keys)
   (let ((nbname (plist-get data :name))
         (nbpath (plist-get data :path)))
-    (when (= (ein:need-notebook-version url-or-port) 2)
+    (when (< (ein:notebook-version-numeric url-or-port) 3)
       (if (string= nbpath "")
           (setq nbpath nbname)
         (setq nbpath (format "%s/%s" nbpath nbname))))
@@ -572,7 +572,7 @@ You may find the new one in the notebook list." error)
   "Render the header (for ipython>=3)."
   (with-current-buffer (ein:notebooklist-get-buffer url-or-port)
     (widget-insert
-     (format "Notebook v%s (%s)\n\n" (ein:$notebooklist-api-version ein:%notebooklist%) url-or-port))
+     (format "Contents API %s (%s)\n\n" (ein:need-notebook-version url-or-port) url-or-port))
 
     (let ((breadcrumbs (generate-breadcrumbs (ein:$notebooklist-path ein:%notebooklist%))))
       (dolist (p breadcrumbs)
@@ -694,7 +694,7 @@ You may find the new one in the notebook list." error)
                      "Dir")
                     (widget-insert " : " name)
                     (widget-insert "\n"))
-          if (and (string= type "file") (> (ein:need-notebook-version url-or-port) 2))
+          if (and (string= type "file") (> (ein:notebook-version-numeric url-or-port) 2))
           do (progn (widget-create
                      'link
                      :notify (lexical-let ((url-or-port url-or-port)

--- a/test/ein-testing-notebook.el
+++ b/test/ein-testing-notebook.el
@@ -39,9 +39,9 @@
          (path (plist-get data :path))
          (kernelspec (make-ein:$kernelspec :name "python" :language "python"))
          (content (make-ein:$content :url-or-port ein:testing-notebook-dummy-url
-                                     :notebook-version 4
+                                     :notebook-version "5.7.0"
                                      :path path)))
-    (cl-letf (((symbol-function 'ein:need-notebook-version) (lambda (&rest ignore) 4))
+    (cl-letf (((symbol-function 'ein:need-notebook-version) (lambda (&rest ignore) "5.7.0"))
               ((symbol-function 'ein:kernel-retrieve-session) #'ignore)
               ((symbol-function 'ein:notebook-enable-autosaves) #'ignore))
       (let ((notebook (ein:notebook-new ein:testing-notebook-dummy-url path kernelspec)))

--- a/test/test-ein-notebooklist.el
+++ b/test/test-ein-notebooklist.el
@@ -7,7 +7,7 @@
             ((symbol-function 'ein:content-query-sessions) #'ignore))
     (ein:notebooklist-open--finish (or url-or-port ein:testing-notebook-dummy-url) nil 
      (make-ein:$content :url-or-port (or url-or-port ein:testing-notebook-dummy-url)
-                        :notebook-version 3
+                        :notebook-version "5.7.0"
                         :path ""))))
 
 (defmacro eintest:notebooklist-is-empty-context-of (func)


### PR DESCRIPTION
Say `Contents API 5.7.4` instead of `Notebook v5` in notebooklist.

EIN doesn't care about the python version (2.7, 3.5) or the
ipython version (5.8.0, 6.2.1).  The "jupyter notebook contents api"
version (currently at 5.7.4) is the thing that matters.