### PR TITLE
Stop bug, Image bug

### DIFF
--- a/features/notebook.feature
+++ b/features/notebook.feature
@@ -60,6 +60,26 @@ Scenario: rename notebook
   And I switch to buffer like "Untitled"
   And rename notebook to "Renamed" succeeds
 
+@image
+Scenario: image fails to materialize initially.  Document this in a test.
+  Given new default notebook
+  And I type "import numpy, math, matplotlib.pyplot as plt"
+  And I press "RET"
+  And I type "x = numpy.linspace(0, 2*math.pi)"
+  And I press "RET"
+  And I type "plt.plot(x, numpy.sin(x))"
+  And I press "RET"
+  And I clear log expr "ein:log-all-buffer-name"
+  And I wait for cell to execute
+  And I dump buffer
+  And I switch to log expr "ein:log-all-buffer-name"
+  Then I should not see "msg_type=display_data"
+  And I switch to buffer like "Untitled"
+  And I wait for cell to execute
+  And I dump buffer
+  And I switch to log expr "ein:log-all-buffer-name"
+  Then I should see "msg_type=display_data"
+
 @switch
 Scenario: switch kernel
   Given new default notebook

--- a/lisp/ein-jupyter.el
+++ b/lisp/ein-jupyter.el
@@ -231,9 +231,13 @@ the log of the running jupyter server."
     ;; Both (quit-process) and (delete-process) leaked child kernels, so signal
     (if (eql system-type 'windows-nt)
         (delete-process proc)
-      (let ((pid (process-id proc)))
+      (lexical-let* ((proc proc)
+                     (pid (process-id proc)))
         (ein:log 'verbose "Signaled %s with pid %s" proc pid)
-        (signal-process pid 15)))
+        (signal-process pid 15)
+        (run-at-time 2 nil (lambda ()
+                             (ein:log 'verbose "Resignaled %s with pid %s" proc pid)
+                             (signal-process pid 15)))))
 
     (ein:log 'info "Stopped Jupyter notebook server.")
 

--- a/lisp/ein-kernel.el
+++ b/lisp/ein-kernel.el
@@ -671,7 +671,6 @@ We need this to have proper behavior for the 'Stop' command in the ein:notebookl
   (puthash msg-id callbacks (ein:$kernel-msg-callbacks kernel)))
 
 (defun ein:kernel--handle-stdin-reply (kernel packet)
-  (ein:log 'debug "KERNEL--HANDLE-STDIN-REPLY")
   (setf (ein:$kernel-stdin-activep kernel) t)
   (destructuring-bind
       (&key header parent_header metadata content &allow-other-keys)
@@ -697,7 +696,6 @@ We need this to have proper behavior for the 'Stop' command in the ein:notebookl
                           (setf (ein:$kernel-stdin-activep kernel) nil))))))))))
 
 (defun ein:kernel--handle-shell-reply (kernel packet)
-  (ein:log 'debug "KERNEL--HANDLE-SHELL-REPLY")
   (destructuring-bind
       (&key header content metadata parent_header &allow-other-keys)
       (ein:json-read-from-string packet)
@@ -716,8 +714,7 @@ We need this to have proper behavior for the 'Stop' command in the ein:notebookl
           (("execute_reply")
            (ein:aif (plist-get content :execution_count)
                ;; It can be `nil' for silent execution
-               (ein:events-trigger events 'execution_count.Kernel it)))))))
-  (ein:log 'debug "KERNEL--HANDLE-SHELL-REPLY: finished"))
+               (ein:events-trigger events 'execution_count.Kernel it))))))))
 
 (defun ein:kernel--handle-payload (kernel callbacks payload)
   (loop with events = (ein:$kernel-events kernel)
@@ -742,7 +739,6 @@ We need this to have proper behavior for the 'Stop' command in the ein:notebookl
              (when cb (ein:funcall-packed cb text)))))
 
 (defun ein:kernel--handle-iopub-reply (kernel packet)
-  (ein:log 'debug "KERNEL--HANDLE-IOPUB-REPLY")
   (if (ein:$kernel-stdin-activep kernel)
       (ein:ipdb--handle-iopub-reply kernel packet)
     (destructuring-bind
@@ -772,8 +768,7 @@ We need this to have proper behavior for the 'Stop' command in the ein:notebookl
              (ein:log 'verbose (format "Received data_pub message w/content %s" packet)))
             (("clear_output")
              (ein:aif (plist-get callbacks :clear_output)
-                 (ein:funcall-packed it content metadata))))))))
-  (ein:log 'debug "KERNEL--HANDLE-IOPUB-REPLY: finished"))
+                 (ein:funcall-packed it content metadata)))))))))
 
 ;;; Utility functions
 

--- a/lisp/ein-pkg.el
+++ b/lisp/ein-pkg.el
@@ -1,7 +1,8 @@
 (define-package "ein"
   "0.16.0"
   "Emacs IPython Notebook"
-  '((websocket "1.7")
+  '((emacs "25")
+    (websocket "1.7")
     (auto-complete "1.4.0")
     (request "0.3")
     (deferred "0.5")

--- a/lisp/ein-pkg.el
+++ b/lisp/ein-pkg.el
@@ -6,7 +6,7 @@
     (auto-complete "1.4.0")
     (request "0.3")
     (deferred "0.5")
-    (polymode "20190102.1910")
+    (polymode "20190426.1729")
     (markdown-mode "20171116.756")
     (dash "2.13.0")
     (s "1.11.0")

--- a/lisp/ein-worksheet.el
+++ b/lisp/ein-worksheet.el
@@ -388,7 +388,8 @@ Normalize `buffer-undo-list' by removing extraneous details, and update the ein:
                          (replace-regexp-in-string
                           "poly-\\|-mode" ""
                           (symbol-name
-                           (pm--get-existing-mode (eieio-oref chunkmode 'mode))))))
+                           (pm--get-existing-mode (eieio-oref chunkmode 'mode)
+                                                  (eieio-oref chunkmode 'fallback-mode))))))
              simple-name)))))))
 
 (cl-defmethod ein:worksheet-set-modified-p ((ws ein:worksheet) dirty)

--- a/lisp/ein.el
+++ b/lisp/ein.el
@@ -5,7 +5,6 @@
 ;; Author:  John Miller <millejoh at millejoh.com>, Takafumi Arakaki <aka.tkf at gmail.com>
 ;; URL: http://millejoh.github.io/emacs-ipython-notebook/
 ;; Keywords: applications, tools
-;; Version: 0.15.0
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/tools/install-cask.sh
+++ b/tools/install-cask.sh
@@ -24,6 +24,7 @@ cask_install_or_reset() {
         set +x
     fi
     cask install || { rm -rf .cask && false; }
+    cask update
     # travis cache
     rsync -vazSHe ssh .cask $HOME/
 }


### PR DESCRIPTION
Initial SIGTERM prompts server to dutifully shutdown kernel, but
another SIGTERM necessary to kill server.  Perhaps ipython changed
since the last time I tested this.

Ipython doesn't send a display_data message upon initial plot
request.  This is probably our bug, or is it?  Document this bug in an
ecukes test.

Also enforce emacs version >= 25