### PR TITLE
ob-ein bugfix

### DIFF
--- a/features/ob-ein.feature
+++ b/features/ob-ein.feature
@@ -22,8 +22,29 @@ Scenario: R and Julia in the same org file
   And I dump buffer
 
 @org
-Scenario: ein-python can be python2 or python3
+Scenario: no session defaults to localhost, and no output shouldn't leave [....]
   Given I stop the server
+  When I open temp file "ecukes.org"
+  And I call "org-mode"
+  And I type "<s"
+  And I press "TAB"
+  And I type "ein :results raw drawer"
+  And I press "RET"
+  And I type "(1 + 5 ** 0.5) / 2"
+  And I ctrl-c-ctrl-c
+  And I wait for buffer to say "1.618"
+  And I should not see "[....]"
+  And I press "M->"
+  And I type "<s"
+  And I press "TAB"
+  And I type "ein :session localhost :results raw drawer"
+  And I press "RET"
+  And I type "foo = 5"
+  And I ctrl-c-ctrl-c
+  And I wait for buffer to not say "[....]"
+
+@org
+Scenario: ein-python can be python2 or python3
   When I open temp file "ecukes.org"
   And I call "org-mode"
   And I type "<s"

--- a/features/step-definitions/ein-steps.el
+++ b/features/step-definitions/ein-steps.el
@@ -333,16 +333,18 @@
 (When "^I dump buffer"
       (lambda () (message "%s" (buffer-string))))
 
-(When "^I wait for buffer to say \"\\(.+\\)\"$"
-      (lambda (bogey)
+(When "^I wait for buffer to\\( not\\)? say \"\\(.+\\)\"$"
+      (lambda (negate bogey)
         (ein:testing-wait-until
          (lambda ()
-           (ein:aif (s-contains? (s-replace "\\n" "\n" bogey) (buffer-string)) it
-             (when (with-current-buffer ein:log-all-buffer-name
-                     (search "WS closed unexpectedly" (buffer-string)))
-               (And "I clear log expr \"ein:log-all-buffer-name\"")
-               (Then "I ctrl-c-ctrl-c"))
-             nil))
+           (let* ((says (s-contains? (s-replace "\\n" "\n" bogey) (buffer-string))))
+             (ein:aif (if negate (not says) says)
+                 it
+               (when (with-current-buffer ein:log-all-buffer-name
+                       (search "WS closed unexpectedly" (buffer-string)))
+                 (And "I clear log expr \"ein:log-all-buffer-name\"")
+                 (Then "I ctrl-c-ctrl-c"))
+               nil)))
          nil 40000 2000)))
 
 (When "^I wait for cell to execute$"

--- a/features/undo.feature
+++ b/features/undo.feature
@@ -31,6 +31,8 @@ Scenario: Collapse doesn't break undo
   Given new python notebook
   When I type "from time import sleep"
   And I press "RET"
+  And I wait for cell to execute
+  And I dump buffer
   And I press "C-c C-b"
   And I type "1 + 1"
   And I press "RET"
@@ -44,6 +46,7 @@ Scenario: Collapse doesn't break undo
   And I press "C-n"
   And I type "9"
   And I press "C-<up>"
+  And I dump buffer
   And I press "C-c C-e"
   And I press "C-/"
   And I dump buffer


### PR DESCRIPTION
Currently, an org block that has no output (e.g., foo = 5) never
clears the `[....]` upon completion.

Also, no `:session` should default to localhost.