### PR TITLE
Forestall Polymode "Contamination"

### DIFF
--- a/test/test-ein-poly.el
+++ b/test/test-ein-poly.el
@@ -1,0 +1,10 @@
+(require 'ert)
+(require 'poly-ein)
+(require 'byte-compile)
+
+(ert-deftest ein:should-not-compile-advised ()
+  (should (ad-should-compile 'syntax-ppss nil))
+  (should (ad-should-compile 'syntax-propertize nil))
+  (poly-ein--decorate-functions)
+  (should-not (ad-should-compile 'syntax-ppss nil))
+  (should-not (ad-should-compile 'syntax-propertize nil)))


### PR DESCRIPTION
`advice.el` suggests the `ad-default-compilation-action=maybe` admits
inadvertent byte-compilation of advised syntax-ppss in non-EIN
packages reported in #537.

Prevent this by setting `ad-default-compilation-action=like-original`
when ein:polymode is activated.