### PR TITLE
Do not assume "notebook" subcommand

### DIFF
--- a/features/notebooklist.feature
+++ b/features/notebooklist.feature
@@ -99,6 +99,17 @@ Scenario: Bad curl invocation produces sensible error message
 Scenario: jupyter not found
   And I start bad jupyter path
 
+@jupyter-notebook
+Scenario: Someone uses jupyter-notebook
+  Given I customize "ein:jupyter-default-server-command" to "jupyter-notebook"
+  And I set "ein:jupyter-server-use-subcommand" to eval "nil"
+  Given I start and login to the server configured "\n"
+  And I switch to log expr "ein:log-all-buffer-name"
+  Then I should not see "[warn]"
+  And I should not see "[error]"
+  And I customize "ein:jupyter-default-server-command" to "jupyter"
+  And I set "ein:jupyter-server-use-subcommand" to "notebook"
+
 @login
 Scenario: With token server
   Given I start and login to the server configured "\n"

--- a/features/step-definitions/ein-steps.el
+++ b/features/step-definitions/ein-steps.el
@@ -408,6 +408,10 @@
         (let ((member-p (member value (symbol-value (intern variable)))))
           (if negate (should-not member-p) (should member-p)))))
 
+(When "^I customize \"\\(.+\\)\" to \"\\(.+\\)\"$"
+      (lambda (variable value)
+        (custom-set-variables `(,(intern variable) ,value t))))
+
 (When "^I set \"\\(.+\\)\" to \"\\(.+\\)\"$"
       (lambda (variable value)
         (set (intern variable) value)))

--- a/lisp/ein-core.el
+++ b/lisp/ein-core.el
@@ -61,14 +61,6 @@ Notebook server."
                  (const :tag "First value of `ein:url-or-port'" nil))
   :group 'ein)
 
-(defcustom ein:jupyter-default-server-command "jupyter"
-  "The default command to start a jupyter notebook server.
-
-It is used when the `ein:jupyter-server-start' command is
-interactively called."
-  :group 'ein
-  :type '(file))
-
 (defcustom ein:filename-translations nil
   "Convert file paths between Emacs and Python process.
 


### PR DESCRIPTION
Some users run jupyter via `jupyter-notebook` instead of `jupyter`,
and break because we unilaterally impose the "notebook" subcommand.

Those users can now:
```
M-x customize-group ein
Jupyter Server Use Subcommand: Omit
```