### PR TITLE
git diff origin/HEAD Makefile

### DIFF
--- a/lisp/ein-notebooklist.el
+++ b/lisp/ein-notebooklist.el
@@ -177,8 +177,9 @@ port the instance is running on."
              ;; there may be NO local jupyter installation
              (process-lines ein:jupyter-default-server-command
                             "notebook" "list" "--json")
-           (error (message "Error getting local tokens: %s" err)
-                  ())))         ; empty list
+           (error (ein:log 'verbose "ein:crib-token--all-local-tokens: '%s': %s" 
+                           ein:jupyter-default-server-command err)
+                  '())))         ; empty list
         (url-tokens (make-hash-table :test #'equal)))
     (loop for line in lines
           do (destructuring-bind

--- a/lisp/ein-org.el
+++ b/lisp/ein-org.el
@@ -57,7 +57,12 @@ This function is to be used for FOLLOW function of
   (let ((link (read link-path)))
     (destructuring-bind (&key url-or-port name &allow-other-keys)
         link
-      (ein:notebook-open url-or-port name))))
+      (ein:notebooklist-login 
+       url-or-port 
+       (apply-partially (lambda (url-or-port* path* callback* buffer)
+                          (ein:notebook-open
+                           url-or-port* path* nil callback*))
+                        url-or-port name nil)))))
 
 ;;;###autoload
 (defun ein:org-store-link ()


### PR DESCRIPTION
diff --git a/Makefile b/Makefile
index 9cdee480..454188e2 100644
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ README.rst: README.in.rst lisp/ein.el lisp/ein-notebook.el
 
 .PHONY: autoloads
 autoloads:
-	$(EMACS) -Q --batch --eval "(package-initialize)" --eval "(package-generate-autoloads \"ein\" \"./lisp\")"
+	$(EMACS) -Q --batch -f package-initialize   --eval "(package-generate-autoloads \"ein\" \"./lisp\")"
 
 .PHONY: clean
 clean:
@@ -56,7 +56,7 @@ $(CASK_DIR): Cask
 
 .PHONY: test-compile
 test-compile: clean autoloads
-	! ($(CASK) eval "(let ((byte-compile-error-on-warn t)) (cask-cli/build))" 2>&1 | egrep -a "(Warning|Error):") ; (ret=$$? ; $(CASK) clean-elc && exit $$ret)
+	! ($(CASK) eval "(package-initialize) (let ((byte-compile-error-on-warn t)) (cask-cli/build))" 2>&1 | egrep -a "(Warning|Error):") ; (ret=$$? ; $(CASK) clean-elc && exit $$ret)
 
 .PHONY: quick
 quick: $(CASK_DIR) test-compile test-ob-ein-recurse test-unit
10:56:17 raman-glaptop emacs-ipython-notebook $